### PR TITLE
Issue #17: implemented single line comment \

### DIFF
--- a/src/corelib.fs
+++ b/src/corelib.fs
@@ -29,7 +29,7 @@
 
 
 ( Application functions )
-: fac ( n -- n! ) 
+: fac ( n -- n! )   \ Calculates factorial of a non-negative integer. No checks for stack or calculation overflow.
     dup 
         if 
             1 swap _fac 
@@ -37,7 +37,7 @@
             drop 1 
         then ;
 
-: _fac ( r n -- r ) 
+: _fac ( r n -- r )   \ Helper function that does most of the work.
     dup if 
         tuck * swap 1 - _fac 
     else 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -322,6 +322,9 @@ impl ForthInterpreter {
                         // a builtin's documentation string
                         self.word_see(info.tail.trim());
                     }
+                    "\\" => {
+                        // comment: no execution action
+                    }
                     _ => (),
                 }
             }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -9,12 +9,13 @@ use crate::reader::Reader;
 const BRANCHES: [&str; 9] = [
     "if", "else", "then", "begin", "do", "loop", "until", "repeat", "+loop",
 ];
-const FORWARDS: [(&str, &str); 5] = [
-    ("(", ")"),
-    ("s\"", "\""),
-    (".\"", "\""),
-    ("see", " \t\n"),
-    ("variable", " \t\n"),
+const FORWARDS: [(&str, &str); 6] = [
+    ("(", ")"),            // comment
+    ("s\"", "\""),         // stored string
+    (".\"", "\""),         // inline string print
+    ("see", " \t\n"),      // view word definition
+    ("variable", " \t\n"), // variable declaration
+    ("\\", "\n"),          // comment to end of line
 ];
 
 #[derive(Debug, Clone)]

--- a/washing-machine.fs
+++ b/washing-machine.fs
@@ -1,0 +1,38 @@
+( Washing machine controller )
+
+: run-machine
+	check-door
+	if lock-door run-cycles unlock-door
+	else ." Please close door"
+	then ;
+
+: check-door
+	door-closed @
+	if ." Door is closed." true
+	else false
+	then ;
+
+: lock-door
+	true door-locked ! ." Door has been locked." ;
+
+: unlock-door
+	false door-locked ! ." Door has been unlocked." ;
+
+: check-lock door-locked @ ;
+
+: run-cycles wash rinse spin beep ;
+
+: wash ." Washing..." ;
+: rinse ."  Rinsing..." ;
+: spin check-lock if ."   Spinning..." else ." Door is not locked" then ;
+: beep ."     --BEEP!--" ;
+
+variable door-closed
+	false door-closed ! ( Door is initially open )
+variable door-locked
+	false door-locked ! ( Door is initially unlocked)
+
+: close-door true door-closed ! ." Door has been closed." ;
+
+
+	


### PR DESCRIPTION
Single line comment per Forth standard is `\` . Everything following the backslash is ignored, until the end of the line.