### PR TITLE
Issue 16: Implemented CONSTANT

### DIFF
--- a/src/doc.rs
+++ b/src/doc.rs
@@ -89,12 +89,23 @@ pub fn build_doc_strings() -> HashMap<String, String> {
          Subsequent use of <name> places its address on the stack."
     );
     doc!(
+        "constant",
+        "usage: constant <name> ( v -- ) - creates a new constant called <name>, 
+         taking its value from the stack. 
+         Use of the name places the value (not the address) on the stack. "
+    );
+    doc!(
         "@",
         "( addr -- value ) Replaces the address of a variable with its value"
     );
     doc!(
         "!",
         "( value address -- ) Stores value in the variable at address"
+    );
+    doc!(
+        "\\",
+        "Defines an in-line comment. All text from the \\ to the end of line 
+        will be ignored."
     );
     doc!("abort", "Ends the execution of the current word");
     doc!(

--- a/src/regression.fs
+++ b/src/regression.fs
@@ -110,10 +110,13 @@ false 55 0< test-single
 42 variable y 40 y ! 2 y +! y @ test-single
 42 variable z 42 z ! z ? z @ test-single
 
+."        Constants"
+12 12 constant months months \ a constant with the value 12
+
 ."        Application tests"
 1 0 fac test-single
 1 1 fac test-single
 6 3 fac test-single
-479001600 12 fac test-single
+479001600 12 fac test-single 
 
-test-results
+test-results  \ Checks to see if all tests passed. Errors, if any, are left on the stack.

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -9,12 +9,13 @@ use crate::reader::Reader;
 const BRANCHES: [&str; 9] = [
     "if", "else", "then", "begin", "do", "loop", "until", "repeat", "+loop",
 ];
-const FORWARDS: [(&str, &str); 6] = [
+const FORWARDS: [(&str, &str); 7] = [
     ("(", ")"),            // comment
     ("s\"", "\""),         // stored string
     (".\"", "\""),         // inline string print
     ("see", " \t\n"),      // view word definition
     ("variable", " \t\n"), // variable declaration
+    ("constant", " \t\n"), // constant declaration
     ("\\", "\n"),          // comment to end of line
 ];
 


### PR DESCRIPTION
Added Forth standard constants. 
For example:
`12 constant months \ `creates a constant named `months` with the value `12` from the top of the stack
`months \ `places the value of the constant months (`12` in this case) on the stack.