### PR TITLE
Implemented LEAVE for breaking our of DO LOOP operations.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "${workspaceFolder}/<executable file>",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crate::messages::DebugLevel;
 
 use ::clap::{arg, Command};
 
-const VERSION: &str = "alpha.24.2.3";
+const VERSION: &str = "alpha.24.2.5";
 const WELCOME_MESSAGE: &str = "Welcome to tForth.";
 const EXIT_MESSAGE: &str = "Finished";
 const DEFAULT_CORE: [&str; 2] = ["~/.tforth/corelib.fs", "src/corelib.fs"];
@@ -130,7 +130,7 @@ impl Config {
             // Process one word (in immediate mode), or one definition (compile mode).
             if forth.process_token() {
                 forth.msg.info("main", "   Stack", &forth.stack);
-                forth.msg.debug("main", "   Words", &forth.defined_words);
+                // forth.msg.debug("main", "   Words", &forth.defined_words);
             } else {
                 // Exit if EOF.
                 println!("End of File. Thank you for using tForth!");

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crate::messages::DebugLevel;
 
 use ::clap::{arg, Command};
 
-const VERSION: &str = "alpha.24.2.5";
+const VERSION: &str = "alpha.24.2.7";
 const WELCOME_MESSAGE: &str = "Welcome to tForth.";
 const EXIT_MESSAGE: &str = "Finished";
 const DEFAULT_CORE: [&str; 2] = ["~/.tforth/corelib.fs", "src/corelib.fs"];

--- a/src/regression.fs
+++ b/src/regression.fs
@@ -38,6 +38,17 @@ variable test-num 0 test-num !
 
 : loop+test do i dup dup . +loop ;
 
+: leave-test 
+    do 
+        i dup 
+        if 
+            ." inner" 
+        else 
+            ." leaving" leave 
+        then 
+            i . 
+    loop ;
+
 ."         Clear has to be the first test"
 1 2 3 4 5 clear test-none
 
@@ -64,6 +75,8 @@ variable test-num 0 test-num !
 3 15 7 3 loop-test + + test-dual
 0 0 0 loop-test test-single
 1 64 10 1 loop+test * * test-dual
+-1 0 5 -1 leave-test test-dual
+
 
 ."         Arithmetic"
 5 1 4 + test-single
@@ -111,7 +124,7 @@ false 55 0< test-single
 42 variable z 42 z ! z ? z @ test-single
 
 ."        Constants"
-12 12 constant months months \ a constant with the value 12
+12 12 constant months months test-single \ a constant with the value 12
 
 ."        Application tests"
 1 0 fac test-single

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -6,8 +6,8 @@ use crate::messages::Msg;
 use crate::reader::Reader;
 //use crate::utility;
 
-const BRANCHES: [&str; 9] = [
-    "if", "else", "then", "begin", "do", "loop", "until", "repeat", "+loop",
+const BRANCHES: [&str; 10] = [
+    "if", "else", "then", "begin", "do", "loop", "leave", "until", "repeat", "+loop",
 ];
 const FORWARDS: [(&str, &str); 7] = [
     ("(", ")"),            // comment


### PR DESCRIPTION
Cleaned up branch calculator allowing for implementation of `leave`, which can appear anywhere inside a `do .. loop` control structure. 